### PR TITLE
Fix architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 db/
 *.snap
 krellian-kiosk_*.txt
+
+# MacOS system files
+.DS_Store

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,10 @@ confinement: strict
 grade: devel
 
 architectures:
-  - build-on: [armhf, arm64, amd64]
+  - build-on: armhf
+  - build-on: arm64
+  - build-on: amd64
+  #, , ]
 
 apps:
   krellian-kiosk:


### PR DESCRIPTION
This fixes `Exec format error` during kiosk start.

Based on https://snapcraft.io/docs/architectures documentation

this fixes #105 